### PR TITLE
fix download by building zip on file, not in mem

### DIFF
--- a/liwo_services/export.py
+++ b/liwo_services/export.py
@@ -8,7 +8,10 @@ import logging
 
 
 def add_result_to_zip(result, url, data_dir):
-    """add item to zipfile. this requires extra info from url, retrieve data from data_dir"""
+    """
+    LEGACY: No longer used as of 2025.1.6d, but kept for reference. Build a zip of requested layers in memory and return a BytesIO stream.
+    Was too memory intensive for large TIFFs/shapefiles, so replaced by add_result_to_zip_v2 which builds the zip on disk and returns its path
+    add item to zipfile. this requires extra info from url, retrieve data from data_dir"""
     # TODO Add custom log stream for invalid layers
     log_stream = io.StringIO()
     # define a handler

--- a/liwo_services/main.py
+++ b/liwo_services/main.py
@@ -330,9 +330,9 @@ def getFeatureIdByScenarioId():
     return {"d": json.dumps(result[0])}
 
 
-@v1.route("/liwo.ws/Maps.asmx/DownloadZipFileDataLayers", methods=["POST"])
-@v2.route("/liwo.ws/Maps.asmx/DownloadZipFileDataLayers", methods=["POST"])
-def download_zip():
+@v1.route("/liwo.ws/Maps.asmx/DownloadZipFileDataLayers_v1", methods=["POST"])
+@v2.route("/liwo.ws/Maps.asmx/DownloadZipFileDataLayers_v1", methods=["POST"])
+def download_zip_v1_legacy():
     """
     body: {"layers":"scenario_18734,gebiedsindeling_doorbraaklocaties_buitendijks","name":"test"}
     """
@@ -381,9 +381,9 @@ def download_zip():
         )
     return resp
 
-@v1.route("/liwo.ws/Maps.asmx/DownloadZipFileDataLayers_v2", methods=["POST"])
-@v2.route("/liwo.ws/Maps.asmx/DownloadZipFileDataLayers_v2", methods=["POST"])
-def download_zip_v2():
+@v1.route("/liwo.ws/Maps.asmx/DownloadZipFileDataLayers", methods=["POST"])
+@v2.route("/liwo.ws/Maps.asmx/DownloadZipFileDataLayers", methods=["POST"])
+def download_zip():
     """
     body: {"layers":"scenario_18734,gebiedsindeling_doorbraaklocaties_buitendijks","name":"test"}
     """

--- a/tests/download_issues/test_download.py
+++ b/tests/download_issues/test_download.py
@@ -21,7 +21,7 @@ def test_download(url, name, data):
 def test_download_small():
     print('testing download_small')
     base = "http://localhost:5001/"
-    url = base + "liwo.ws/Maps.asmx/DownloadZipFileDataLayers"
+    url = base + "liwo.ws/Maps.asmx/DownloadZipFileDataLayers_v1"
     name =  "test_download_small.zip"
     data = {'layers': 'MaximaleWaterdiepteNederland_Kaart1', 'name': name}
     test_download(url, name, data)
@@ -29,7 +29,7 @@ def test_download_small():
 def test_download_large():
     print('testing download_large')
     base = "http://localhost:5001/"
-    url = base + "liwo.ws/Maps.asmx/DownloadZipFileDataLayers"
+    url = base + "liwo.ws/Maps.asmx/DownloadZipFileDataLayers_v1"
     name =  "test_download_large.zip"
     data = {'layers': 'MaximaleWaterdiepteNederland_Kaart5', 'name': name}
     test_download(url, name, data)

--- a/tests/download_issues/test_download.sh
+++ b/tests/download_issues/test_download.sh
@@ -23,7 +23,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-URL="${BASE_URL}liwo.ws/Maps.asmx/DownloadZipFileDataLayers"
+URL="${BASE_URL}liwo.ws/Maps.asmx/DownloadZipFileDataLayers_v1"
 
 download_test() {
     local name="$1"

--- a/tests/download_issues/test_download_v2.py
+++ b/tests/download_issues/test_download_v2.py
@@ -21,7 +21,7 @@ def test_download(url, name, data):
 def test_download_small():
     print('testing download_small')
     base = "http://localhost:5001/"
-    url = base + "liwo.ws/Maps.asmx/DownloadZipFileDataLayers_v2"
+    url = base + "liwo.ws/Maps.asmx/DownloadZipFileDataLayers"
     name =  "test_download_small.zip"
     data = {'layers': 'MaximaleWaterdiepteNederland_Kaart1', 'name': name}
     test_download(url, name, data)
@@ -29,7 +29,7 @@ def test_download_small():
 def test_download_large():
     print('testing download_large')
     base = "http://localhost:5001/"
-    url = base + "liwo.ws/Maps.asmx/DownloadZipFileDataLayers_v2"
+    url = base + "liwo.ws/Maps.asmx/DownloadZipFileDataLayers"
     name =  "test_download_large.zip"
     data = {'layers': 'MaximaleWaterdiepteNederland_Kaart5', 'name': name}
     test_download(url, name, data)

--- a/tests/download_issues/test_download_v2.sh
+++ b/tests/download_issues/test_download_v2.sh
@@ -23,7 +23,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-URL="${BASE_URL}liwo.ws/Maps.asmx/DownloadZipFileDataLayers_v2"
+URL="${BASE_URL}liwo.ws/Maps.asmx/DownloadZipFileDataLayers"
 
 download_test() {
     local name="$1"


### PR DESCRIPTION
This pull request updates the download endpoints for zipped data layers to clarify legacy and current API versions, and aligns the associated tests accordingly. The main change is to make the v2 implementation the default `/DownloadZipFileDataLayers` endpoint, while moving the legacy implementation to a versioned path. This improves clarity for API consumers and helps maintain backward compatibility.

**API endpoint changes:**

* The legacy download endpoint is now accessible via `/DownloadZipFileDataLayers_v1` (and the handler is renamed to `download_zip_v1_legacy`), while `/DownloadZipFileDataLayers` now points to the v2 implementation (`download_zip`) [[1]](diffhunk://#diff-64b57f5ca3eb795b567565774fbed3debebd0b8482dd9f63a2fde22413350f23L333-R335) [[2]](diffhunk://#diff-64b57f5ca3eb795b567565774fbed3debebd0b8482dd9f63a2fde22413350f23L384-R386).
* The docstring for `add_result_to_zip` in `export.py` was updated to clarify that it's a legacy function, replaced by a more efficient on-disk implementation (`add_result_to_zip_v2`).

**Test updates:**

* All test scripts and Python test files for the legacy endpoint now use `/DownloadZipFileDataLayers_v1` [[1]](diffhunk://#diff-029c6da3882c7b6d58ec05948fe939acb9022153c41b33ef20456b1293d83aabL24-R32) [[2]](diffhunk://#diff-329f5be161ad51b2157bdf8bb215fab3fc22adbd176364012d5975f2ebd87da7L26-R26).
* All test scripts and Python test files for the v2 endpoint now use `/DownloadZipFileDataLayers` [[1]](diffhunk://#diff-d14e50b53f8a1909cafb858f627198f68e28556a826fcdf10fef77b2879f5038L24-R32) [[2]](diffhunk://#diff-5daa1f05dac70eceea1eccb6dd41c481db393f8e050eaea9126c1014ea1e450fL26-R26).